### PR TITLE
feat: :sparkles: Update 'automatico' field behavior

### DIFF
--- a/app/lotus/models/ativos_ti.py
+++ b/app/lotus/models/ativos_ti.py
@@ -56,7 +56,7 @@ class AtivoTI(models.Model):
     numero_serie = models.CharField(max_length=50, blank=True)
     em_uso = models.BooleanField(default=False)
     descricao = models.TextField(blank=True)
-    automatico = models.BooleanField(default=True)
+    automatico = models.BooleanField(default=False)
     local = models.ForeignKey(
         Sala,
         on_delete=models.SET_NULL,

--- a/app/lotus/serializers/agente.py
+++ b/app/lotus/serializers/agente.py
@@ -23,6 +23,11 @@ class AgenteBaseSerializer(serializers.ModelSerializer):
         )
         return obj
 
+    def validate(self, attrs: dict) -> dict:
+        """Força o campo 'automatico' como True."""
+        attrs["automatico"] = True
+        return super().validate(attrs)
+
 
 class AgenteCoreSerializer(AgenteBaseSerializer):
     """Serializer de criação p/ computadores com iformações core vindas do agente."""


### PR DESCRIPTION
Update 'automatico' field to default to False in AtivoTI model and enforce True in AgenteBaseSerializer validation